### PR TITLE
removed haml indention so #notice:empty would work

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -7,11 +7,11 @@
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application', 'data-turbolinks-track': 'reload'
   %body{:class => "#{controller.controller_name}"}
-
     #banner
       = image_tag('logo.svg', alt: 'The Pragmatic Bookshelf')
-      %span.title
-        = @page_title
+      %span
+        .title
+          = @page_title
     #columns
       #side
         %ul
@@ -27,5 +27,5 @@
           %li
             %a(href="#/contact")
               Questions
-    #main
-      = yield
+      #main
+        = yield

--- a/app/views/store/index.html.haml
+++ b/app/views/store/index.html.haml
@@ -1,8 +1,7 @@
 -# %h1 Store#index
 -# %p Find me in app/views/store/index.html.haml
 
-%p#notice
-  = notice
+%p#notice= notice
 
 %h1 Your Pragmatic Catalog
 


### PR DESCRIPTION
Inspecting in Chrome *with* indention looked like:

<div id="notice">

</div>

Apparently haml indention made it like that. Resolved by `%p#notice= notice`